### PR TITLE
Cluster URL changed

### DIFF
--- a/ansible/roles/build-cloud-node/tasks/main.yml
+++ b/ansible/roles/build-cloud-node/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Add master node record
   local_action:
     module: uri
-    url: "{{ netsil_api_url }}/organizations/{{ org_id }}/clusters/{{ cluster_id }}/nodes"
+    url: "{{ netsil_api_url }}/clusters/{{ cluster_id }}/nodes"
     method: POST
     validate_certs: "{{ validate_certs }}"
     headers:

--- a/ansible/roles/build-cloud-node/tasks/provider/aws.yml
+++ b/ansible/roles/build-cloud-node/tasks/provider/aws.yml
@@ -36,6 +36,7 @@
   set_fact:
     master_public_ip: "{{ netsil_master.instances[0].public_ip }}"
     master_private_ip: "{{ netsil_master.instances[0].private_ip }}"
+    node_id: "{{ netsil_master.instances[0].id }}"
 
 - name: Wait for master SSH
   wait_for:

--- a/ansible/roles/remove-cloud-node/tasks/main.yml
+++ b/ansible/roles/remove-cloud-node/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Delete node record
   local_action:
     module: uri
-    url: "{{ netsil_api_url }}/organizations/{{ org_id }}/clusters/{{ cluster_id }}/nodes/{{ instance_id }}"
+    url: "{{ netsil_api_url }}/clusters/{{ cluster_id }}/nodes/{{ instance_id }}"
     method: DELETE
     validate_certs: "{{ validate_certs }}"
     headers:

--- a/ansible/roles/update-cluster/tasks/main.yml
+++ b/ansible/roles/update-cluster/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Update cluster record
   local_action:
     module: uri
-    url: "{{ netsil_api_url }}/organizations/{{ org_id }}/clusters/{{ cluster_id }}"
+    url: "{{ netsil_api_url }}/clusters/{{ cluster_id }}"
     method: PUT
     validate_certs: "{{ validate_certs }}"
     headers:


### PR DESCRIPTION
This flattens the cluster data structure which is related to making the API more stateless by removing stored provider and org/user info.